### PR TITLE
Fix config SMS update and view include

### DIFF
--- a/app/Http/Controllers/ConfigController.php
+++ b/app/Http/Controllers/ConfigController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Clases\Welcome;
 use App\Http\Requests\UpdateMessageRequest;
 use App\Message;
 use Illuminate\Http\Request;
@@ -15,9 +14,21 @@ class ConfigController extends Controller
         $sms = Message::first();
         return view('admin.config.index',compact('sms'));
     }
-    public function storeSms(UpdateMessageRequest $request){
-        //$this->welcome->setMessage($request->all());
-        Alert::message('Mensaje actualizado con exito','success');
+    public function storeSms(UpdateMessageRequest $request)
+    {
+        $sms = Message::first();
+
+        if ($sms) {
+            $sms->update($request->only('message', 'type'));
+        } else {
+            Message::create([
+                'name'    => 'SMS',
+                'message' => $request->input('message'),
+                'type'    => $request->input('type'),
+            ]);
+        }
+
+        Alert::message('Mensaje actualizado con exito', 'success');
         return redirect()->route('config');
     }
 

--- a/resources/views/admin/messages/ajax/edit.blade.php
+++ b/resources/views/admin/messages/ajax/edit.blade.php
@@ -7,7 +7,7 @@
             {!! Form::model($sector,['route'=>['message.update',$sector],'method' => 'PUT','class' => 'form-horizontal form-bordered', 'id'=>'form-edit']) !!}
             <div class="modal-wrapper">
                 <div class="modal-text">
-                    @include('admin.messajes.partials.fields')
+                    @include('admin.messages.partials.fields')
                 </div>
             </div>
             <footer class="card-footer">


### PR DESCRIPTION
## Summary
- fix message update logic in ConfigController
- correct include path in message edit view

## Testing
- `composer install --no-interaction` *(fails: command not found)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68425ddfd838832e913a9939159084ab