### PR TITLE
Fix percentage helper typo

### DIFF
--- a/app/Helpers/VariosHelpers.php
+++ b/app/Helpers/VariosHelpers.php
@@ -11,6 +11,6 @@ function difVoters($nvoter,$nvoterR){
     return  intval($nvoter) - $nvoterR;
 }
 
-function porcentajeCumplimineto($nvoter,$nvoterR){
-    return $nvoter === 0 ? '0%' :round((intval($nvoterR)*100)/$nvoter, 1).''.'%';
+function porcentajeCumplimiento($nvoter,$nvoterR){
+    return $nvoter === 0 ? '0%' :round((intval($nvoterR)*100)/$nvoter, 1).'%';
 }

--- a/resources/views/admin/tracking/leaders.blade.php
+++ b/resources/views/admin/tracking/leaders.blade.php
@@ -36,7 +36,7 @@
                     <td class="center d-lg-none" >{{$leader->voters_count}}</td>
                     <td >{{$leader->sufragio_count}}</td>
                     <td >{{$leader->pending_sufragio_count}}</td>
-                    <td class="center d-lg-none" >{{porcentajeCumplimineto($leader->voters_count,$leader->sufragio_count)}}</td>
+                    <td class="center d-lg-none" >{{porcentajeCumplimiento($leader->voters_count,$leader->sufragio_count)}}</td>
                     <td >
                         <a href="{{route('tracking.leaders.notification',$leader)}}"  class="mb-1 mt-1 on-default edit-row btn btn-xs btn-success" ><i class="fas fa-sms"></i> Enviar Mensaje</a>
                         <a href="{{route('tracking.leaders.faltantes',$leader)}}"  class="mb-1 mt-1 on-default edit-row btn btn-xs btn-danger" ><i class="fas fa-meh-rolling-eyes"></i> Faltantes</a>


### PR DESCRIPTION
## Summary
- fix typo in `porcentajeCumplimiento` helper and remove unused concatenation
- update leaders view to use the corrected helper

## Testing
- `php artisan config:clear` *(fails: php not installed)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425f93031c832e9156d33b9318cdc1