### PR TITLE
Fix request class annotations for E14 controller

### DIFF
--- a/app/Http/Controllers/E14Controller.php
+++ b/app/Http/Controllers/E14Controller.php
@@ -39,7 +39,7 @@ class E14Controller extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  CreateE14Request  $request
      * @return \Illuminate\Http\Response
      */
     public function store(CreateE14Request $request)
@@ -75,7 +75,7 @@ class E14Controller extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  UpdateE14Request  $request
      * @param  \App\E14  $e14
      * @return \Illuminate\Http\Response
      */


### PR DESCRIPTION
## Summary
- reference `CreateE14Request` and `UpdateE14Request` in `store()` and `update()` phpdoc

## Testing
- `composer --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425f95b97c832e9dc8772cb4d29fbe